### PR TITLE
Fix a VERY embarrassing issue

### DIFF
--- a/postload.js
+++ b/postload.js
@@ -81,7 +81,7 @@ ccmod.patchStepsLib.callable.register('FUNCTION', async function (state, args) {
   // New function
   const newSteps = [];
   newSteps.push({
-    type: 'EXIT',
+    type: 'EXIT_SM',
   });
 
   newSteps.push({
@@ -119,7 +119,7 @@ ccmod.patchStepsLib.callable.register('IF', async function (state, args) {
   if (ifIndex == -1) {
     const newSteps = [];
     newSteps.push({
-      type: 'EXIT',
+      type: 'EXIT_SM',
     });
 
     newSteps.push({
@@ -159,8 +159,8 @@ ccmod.patchStepsLib.callable.register('PRINT_STEPS', async function (state, _arg
 });
 
 /**
- * EXIT step, tells the step machine we are finished.
+ * EXIT_SM step, tells the step machine we are finished.
  */
-ccmod.patchStepsLib.callable.register('EXIT', async function (state) {
+ccmod.patchStepsLib.callable.register('EXIT_SM', async function (state) {
   state.stepMachine.exit();
 });


### PR DESCRIPTION
Hopefully fix the custom patch steps causing errors for the mod. For the technically inclined, let me explain.

In patch steps, we have a step called `ENTER` that allows you to move the
context into a specific array or object. You can move the context as far into
an object as you want. To go back, we also have a step called `EXIT`. Calling
this as-is puts you back one, and it also takes a number that dictates how far
back you go.

In my custom patch steps, an internal step was defined named `EXIT` that stops
the patch machine (the thing that takes care of logic flow) to let it know we
are done.

Apparently, that was overriding the builtin `EXIT` call and breaking
functionality. To fix this, I have renamed this custom step to `EXIT_SM`. It
seems to work fine.
