### PR TITLE
PVP fixes & improvements

### DIFF
--- a/js/pvp-gui-fix.js
+++ b/js/pvp-gui-fix.js
@@ -16,7 +16,11 @@ sc.PvpModel.inject({
         ig.vars.set('tmp.pvp_' + name + '_defeated', true)
         sc.Model.notifyObserver(this, sc.PVP_MESSAGE.COMBATANT_DEFEATED, combatant)
         /* speed up the game when the player is defeated */
-        if (name == 'player' && sc.pvp.enemies.length > 1) setTimeout(() => (ig.system.skipMode = true), 3000)
+        if (name == 'player' && sc.pvp.enemies.length > 1) setTimeout(() => {
+            if (combatant.isDefeated()) {
+                ig.system.skipMode = true
+            }
+        }, 3000)
         return this.parent(combatant)
     },
     startNextRound(autoContinue) {

--- a/js/pvp-gui-fix.js
+++ b/js/pvp-gui-fix.js
@@ -1,26 +1,96 @@
-ig.EVENT_STEP.START_PVP_BATTLE.inject({
-  init(a) {
-    this.parent(a);
+sc.PartyModel.inject({
+    _spawnPartyMemberEntity(partyMemberName, showEffects, idx, npc) {
+        this.parent(partyMemberName, showEffects, idx, npc)
+        /* fix sc.PartyMemberEntity not inheriting their name from ig.ENTITY.NPC */
+        this.partyEntities[partyMemberName].name = npc?.name
+    },
+})
 
-    let b = 110 + sc.pvp.winPoints * 10;
-    b += (sc.party.getPartySize() + 1) * 16;
-    b += a.enemies.length * 16;
-    
-    const combatHudGui = ig.gui.guiHooks.find(ui => 
-      ui.gui instanceof sc.CombatHudGui
-    );
+// @ts-expect-error
+sc.PVP_MESSAGE.COMBATANT_DEFEATED = 4
+// @ts-expect-error
+sc.PVP_MESSAGE.ROUND_START = 5
+sc.PvpModel.inject({
+    onPvpCombatantDefeat(combatant) {
+        const name = combatant == ig.game.playerEntity ? 'player' : combatant.name
+        ig.vars.set('tmp.pvp_' + name + '_defeated', true)
+        sc.Model.notifyObserver(this, sc.PVP_MESSAGE.COMBATANT_DEFEATED, combatant)
+        /* speed up the game when the player is defeated */
+        if (name == 'player' && sc.pvp.enemies.length > 1) setTimeout(() => (ig.system.skipMode = true), 3000)
+        return this.parent(combatant)
+    },
+    startNextRound(autoContinue) {
+        ig.system.skipMode = false
+        this.parent(autoContinue)
+        sc.Model.notifyObserver(this, sc.PVP_MESSAGE.ROUND_START, null)
+    },
+    start(winPoints, enemies) {
+        sc.SUB_HP_EDITOR.PVP.hpBars = []
+        this.parent(winPoints, enemies)
+    },
+})
+sc.SUB_HP_EDITOR.PVP.orderGlobal = 0
+sc.SUB_HP_EDITOR.PVP.hpBars = []
+sc.SUB_HP_EDITOR.PVP.rearrangeAll = function () {
+    sc.SUB_HP_EDITOR.PVP.hpBars = sc.SUB_HP_EDITOR.PVP.hpBars.sort((a, b) => a.order - b.order)
+    for (let i = 0; i < sc.SUB_HP_EDITOR.PVP.hpBars.length; i++) {
+        const bar = sc.SUB_HP_EDITOR.PVP.hpBars[i]
+        bar.setPos(bar.hook.pos.x, i * 25 + 5)
+    }
+}
+sc.SUB_HP_EDITOR.PVP.inject({
+    init(enemy) {
+        this.parent(enemy)
+        this.order = sc.SUB_HP_EDITOR.PVP.orderGlobal++
+        sc.SUB_HP_EDITOR.PVP.hpBars.push(this)
+        sc.SUB_HP_EDITOR.PVP.rearrangeAll()
+    },
+    remove(immediately) {
+        this.parent(immediately)
+        sc.SUB_HP_EDITOR.PVP.hpBars.erase(this)
+        sc.SUB_HP_EDITOR.PVP.rearrangeAll()
+    },
+})
 
-    combatHudGui.gui.upperGui.sub.pvp.setSize(b, 20);
-  },
+ig.GUI.StatusBar.inject({
+    init(combatant) {
+        sc.Model.addObserver(sc.pvp, this)
+        this.parent(combatant)
+    },
+    modelChanged(model, message, data) {
+        this.parent(model, message, data)
+        if (model == sc.pvp) {
+            if (message == sc.PVP_MESSAGE.COMBATANT_DEFEATED) {
+                if (sc.pvp.enemies.length > 1 && this.target instanceof ig.ENTITY.Combatant && this.target.isDefeated()) {
+                    this.subHpHandler?.remove()
+                    this.doStateTransition('HIDDEN', false, true)
+                }
+            } else if (message == sc.PVP_MESSAGE.ROUND_START) {
+                if (this.target instanceof ig.ENTITY.Combatant && this.hook.currentStateName == 'HIDDEN') {
+                    // @ts-expect-error
+                    this.subHpType = 'forceUpdateSubHpHandlerBySettingThisVariableToNonsense'
+                    this.updateSubHpHandler()
+                    this.doStateTransition('DEFAULT')
+                }
+            }
+        }
+    },
+})
 
-  start(a, b) {
-    this.parent(a, b);
-
-    for (let i = 0; i < this.enemies.length; i++) {
-      let enemy = ig.Event.getEntity(this.enemies[i], b);
-      let ui = enemy.statusGui.subHpHandler;
-      ui.setPos(ui.hook.pos.x, i * 25 + 5);
-    };
-  }
-});
-
+sc.CombatUpperHud.inject({
+    init() {
+        this.parent()
+        sc.Model.addObserver(sc.pvp, this)
+    },
+    modelChanged(model, message, data) {
+        this.parent && this.parent(model, message, data)
+        if (model == sc.pvp) {
+            if (message == sc.PVP_MESSAGE.STARTED) {
+                const winPointsLen = sc.pvp.winPoints * 10
+                const len = Math.max(sc.party.getPartySize() + 1, sc.pvp.enemies.length)
+                let w = 50 + winPointsLen + len * 16 * 2
+                this.sub.pvp.setSize(w, 20)
+            }
+        }
+    },
+})

--- a/js/pvp-gui-fix.js
+++ b/js/pvp-gui-fix.js
@@ -66,7 +66,7 @@ ig.GUI.StatusBar.inject({
         if (model == sc.pvp) {
             if (message == sc.PVP_MESSAGE.COMBATANT_DEFEATED) {
                 if (sc.pvp.enemies.length > 1 && this.target instanceof ig.ENTITY.Combatant && this.target.isDefeated()) {
-                    this.subHpHandler?.remove()
+                    this.subHpHandler && this.subHpHandler.remove()
                     this.doStateTransition('HIDDEN', false, true)
                 }
             } else if (message == sc.PVP_MESSAGE.ROUND_START) {

--- a/js/pvp-gui-fix.js
+++ b/js/pvp-gui-fix.js
@@ -2,7 +2,7 @@ sc.PartyModel.inject({
     _spawnPartyMemberEntity(partyMemberName, showEffects, idx, npc) {
         this.parent(partyMemberName, showEffects, idx, npc)
         /* fix sc.PartyMemberEntity not inheriting their name from ig.ENTITY.NPC */
-        this.partyEntities[partyMemberName].name = npc?.name
+        if (npc) this.partyEntities[partyMemberName].name = npc.name
     },
 })
 
@@ -12,7 +12,7 @@ sc.PVP_MESSAGE.COMBATANT_DEFEATED = 4
 sc.PVP_MESSAGE.ROUND_START = 5
 sc.PvpModel.inject({
     onPvpCombatantDefeat(combatant) {
-        const name = combatant == ig.game.playerEntity ? 'player' : combatant.name
+        const name = combatant ? (combatant == ig.game.playerEntity ? 'player' : combatant.name) : ''
         ig.vars.set('tmp.pvp_' + name + '_defeated', true)
         sc.Model.notifyObserver(this, sc.PVP_MESSAGE.COMBATANT_DEFEATED, combatant)
         /* speed up the game when the player is defeated */


### PR DESCRIPTION
- Fix player heads being improperly alligend
- Remove enemy PVP health bars when they die
- Speed up the game when you die in a PVP fight
